### PR TITLE
Fix missing URL conf for mainapp

### DIFF
--- a/mainapp/urls.py
+++ b/mainapp/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('', views.main, name='main'),
+    path('category/<int:pk>/', views.blog, name='category'),
+    path('category/<int:pk>/page/<int:page>/', views.blog, name='page'),
+    path('download/<int:pk>/', views.download_count, name='download'),
+]


### PR DESCRIPTION
## Summary
- add mainapp.urls module so Django can include it

## Testing
- `pip install django==5.2.3` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6859adfb3f4c83269c8c247b9840af70